### PR TITLE
Fixed authenticationheader time issue

### DIFF
--- a/Private/New-AuthenticationHeader.ps1
+++ b/Private/New-AuthenticationHeader.ps1
@@ -28,7 +28,7 @@ function New-AuthenticationHeader {
         $AuthenticationHeader = @{
             "Content-Type" = "application/json"
             "Authorization" = $AccessToken.CreateAuthorizationHeader()
-            "ExpiresOn" = $AccessToken.ExpiresOn.LocalDateTime
+            "ExpiresOn" = $AccessToken.ExpiresOn.UTCDateTime
         }
 
         # Handle return value


### PR DESCRIPTION
Changes the localtimedate to utctimedate to prevent issue of the header saying the token is invalid due to time differences.