### PR TITLE
Adding an MSISilentInstall switch parameter to Add-IntuneWin32App

### DIFF
--- a/Private/New-IntuneWin32AppBody.ps1
+++ b/Private/New-IntuneWin32AppBody.ps1
@@ -276,6 +276,7 @@ function New-IntuneWin32AppBody {
 
             if($MSISilentInstall){
                 $Win32AppBody.installCommandLine += " /quiet"
+                $Win32AppBody.uninstallCommandLine += " /quiet"
             }
 
             # Add icon property if passed on command line

--- a/Private/New-IntuneWin32AppBody.ps1
+++ b/Private/New-IntuneWin32AppBody.ps1
@@ -83,6 +83,9 @@ function New-IntuneWin32AppBody {
     
     .PARAMETER MSIUpgradeCode
         Specify the MSI upgrade code for the Win32 application body.
+
+    .PARAMETER MSISilentInstall
+        Specify the MSISilentInstall parameter switch if you want the MSI installer to run without a GUI. 
             
     .NOTES
         Author:      Nickolaj Andersen
@@ -98,6 +101,7 @@ function New-IntuneWin32AppBody {
         1.0.3 - (2022-09-02) minimumSupportedOperatingSystem property is replaced by minimumSupportedWindowsRelease
                              Fixed a bug where minimumFreeDiskSpaceInMB, minimumMemoryInMB, minimumNumberOfProcessors and minimumCpuSpeedInMHz
                              would never contain any value since they're not handled by this function (https://github.com/MSEndpointMgr/IntuneWin32App/issues/44)
+        1.0.4 - (2022-11-28) Added MSISilentInstall parameter switch to allow MSIs to be installed with the /quiet switch
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
@@ -213,7 +217,11 @@ function New-IntuneWin32AppBody {
 
         [parameter(Mandatory = $true, ParameterSetName = "MSI", HelpMessage = "Specify the MSI upgrade code for the Win32 application body.")]
         [ValidateNotNullOrEmpty()]
-        [string]$MSIUpgradeCode
+        [string]$MSIUpgradeCode,
+
+        [parameter(Mandatory = $false, ParameterSetName = "MSI", HelpMessage = "Define that the MSI installer with run without a GUI.")]
+        [ValidateNotNullOrEmpty()]
+        [switch]$MSISilentInstall
     )
     # Determine values for requirement rules
     if ($PSBoundParameters["RequirementRule"]) {
@@ -264,6 +272,10 @@ function New-IntuneWin32AppBody {
                 }
                 "publisher" = $Publisher
                 "runAs32bit" = $false
+            }
+
+            if($MSISilentInstall){
+                $Win32AppBody.installCommandLine += " /quiet"
             }
 
             # Add icon property if passed on command line

--- a/Public/Add-IntuneWin32App.ps1
+++ b/Public/Add-IntuneWin32App.ps1
@@ -69,6 +69,9 @@ function Add-IntuneWin32App {
     .PARAMETER UseAzCopy
         Specify the UseAzCopy parameter switch when adding an application with source files larger than 500MB.
 
+    .PARAMETER MSISilentInstall
+        Specify the MSISilentInstall parameter switch if you want the MSI installer to run without a GUI. 
+
     .NOTES
         Author:      Nickolaj Andersen
         Contact:     @NickolajA
@@ -87,6 +90,7 @@ function Add-IntuneWin32App {
         1.0.8 - (2022-10-02) Added UseAzCopy parameter switch to override the native transfer method. Specify the UseAzCopy parameter switch when uploading large applications.
                              Added fallback removal code for the cleanup operation at the end of this function, since OneDrive's Files On Demand feature sometimes blocks the 
                              expanded .intunewin file cleanup process.
+        1.0.9 - (2022-11-28) Added MSISilentInstall parameter switch to allow MSIs to be installed with the /quiet switch
     #>
     [CmdletBinding(SupportsShouldProcess=$true, DefaultParameterSetName = "MSI")]
     param(
@@ -204,7 +208,11 @@ function Add-IntuneWin32App {
         [parameter(Mandatory = $false, ParameterSetName = "MSI", HelpMessage = "Specify the UseAzCopy parameter switch when adding an application with source files larger than 500MB.")]
         [parameter(Mandatory = $false, ParameterSetName = "EXE")]
         [ValidateNotNullOrEmpty()]
-        [switch]$UseAzCopy
+        [switch]$UseAzCopy,
+
+        [parameter(Mandatory = $false, ParameterSetName = "MSI", HelpMessage = "Define that the MSI installer with run without a GUI.")]
+        [ValidateNotNullOrEmpty()]
+        [switch]$MSISilentInstall
     )
     Begin {
         # Ensure required authentication header variable exists
@@ -297,6 +305,7 @@ function Add-IntuneWin32App {
                             "MSIProductVersion" = $IntuneWinXMLMetaData.ApplicationInfo.MsiInfo.MsiProductVersion
                             "MSIRequiresReboot" = $MSIRequiresReboot
                             "MSIUpgradeCode" = $IntuneWinXMLMetaData.ApplicationInfo.MsiInfo.MsiUpgradeCode
+                            "MSISilentInstall" = $MSISilentInstall
                         }
                         if ($PSBoundParameters["Icon"]) {
                             $AppBodySplat.Add("Icon", $Icon)


### PR DESCRIPTION
Packages in my Organisation are designed to run silently with no user interaction. The way that the module is currently setup doesn't allow for this and would need to be added to Intune then edited manually before assigning to users. 

Adding a [switch] parameter to Add-IntuneWin32App (New-IntuneWin32AppBody by extension) to allow people to specify if they want their MSI packages to run silently. 

End effect is just appending " /quiet" the install / uninstall commands for MSI packages. 

Tested changes internally and has worked for me. Thought others might benefit. 