### PR TITLE
Add RoleScopeTagIDs and fix issue with showing Graph API error messages on PowerShell Core

### DIFF
--- a/Private/Invoke-AzureADGraphRequest.ps1
+++ b/Private/Invoke-AzureADGraphRequest.ps1
@@ -55,3 +55,4 @@ function Invoke-AzureADGraphRequest {
         Write-Warning -Message "Request to $($GraphURI) failed with HTTP Status $($_.Exception.Response.StatusCode) and description: $($_.Exception.Response.StatusDescription)"
     }
 }
+

--- a/Private/Invoke-AzureADGraphRequest.ps1
+++ b/Private/Invoke-AzureADGraphRequest.ps1
@@ -40,8 +40,15 @@ function Invoke-AzureADGraphRequest {
         return $GraphResponse
     }
     catch [System.Exception] {
-        # Construct stream reader for reading the response body from API call
-        $ResponseBody = Get-ErrorResponseBody -Exception $_.Exception
+        Switch ($PSEdition) {
+            'Desktop' {
+                # Construct stream reader for reading the response body from API call
+                $ResponseBody = Get-ErrorResponseBody -Exception $_.Exception
+            }
+            'Core' {
+                $ResponseBody = $_.ErrorDetails.Message
+            }
+        }
 
         # Handle response output and error message
         Write-Output -InputObject "Response content:`n$ResponseBody"

--- a/Private/Invoke-IntuneGraphRequest.ps1
+++ b/Private/Invoke-IntuneGraphRequest.ps1
@@ -66,8 +66,15 @@ function Invoke-IntuneGraphRequest {
         return $GraphResponse
     }
     catch [System.Exception] {
-        # Construct stream reader for reading the response body from API call
-        $ResponseBody = Get-ErrorResponseBody -Exception $_.Exception
+        Switch ($PSEdition) {
+            'Desktop' {
+                # Construct stream reader for reading the response body from API call
+                $ResponseBody = Get-ErrorResponseBody -Exception $_.Exception
+            }
+            'Core' {
+                $ResponseBody = $_.ErrorDetails.Message
+            }
+        }
 
         # Handle response output and error message
         Write-Output -InputObject "Response content:`n$ResponseBody"

--- a/Private/Invoke-IntuneGraphRequest.ps1
+++ b/Private/Invoke-IntuneGraphRequest.ps1
@@ -81,3 +81,4 @@ function Invoke-IntuneGraphRequest {
         Write-Warning -Message "Request to $($GraphURI) failed with HTTP Status $($_.Exception.Response.StatusCode) and description: $($_.Exception.Response.StatusDescription)"
     }
 }
+

--- a/Public/Add-IntuneWin32App.ps1
+++ b/Public/Add-IntuneWin32App.ps1
@@ -29,6 +29,9 @@ function Add-IntuneWin32App {
 
     .PARAMETER Notes
         Specify the notes property for the Win32 application.
+    
+    .PARAMETER RoleScopeTagIDs
+        Specify the role scope tag IDs for the Win32 application.
 
     .PARAMETER InformationURL
         Specify the information URL for the Win32 application.
@@ -141,6 +144,11 @@ function Add-IntuneWin32App {
         [parameter(Mandatory = $false, ParameterSetName = "MSI", HelpMessage = "Specify the notes property for the Win32 application.")]
         [parameter(Mandatory = $false, ParameterSetName = "EXE")]
         [string]$Notes = [string]::Empty,
+
+        [parameter(Mandatory = $false, ParameterSetName = "MSI", HelpMessage = "Specify the role scope tag IDs for the Win32 application.")]
+        [parameter(Mandatory = $false, ParameterSetName = "EXE")]
+        [ValidateNotNullOrEmpty()]
+        [string[]]$RoleScopeTagIDs = [string]::Empty,
 
         [parameter(Mandatory = $false, ParameterSetName = "MSI", HelpMessage = "Specify the information URL for the Win32 application.")]
         [parameter(Mandatory = $false, ParameterSetName = "EXE")]
@@ -370,6 +378,9 @@ function Add-IntuneWin32App {
                 if ($PSBoundParameters["AdditionalRequirementRule"]) {
                     $Win32AppBody.Add("requirementRules", $AdditionalRequirementRule)
                 }
+
+                # Add role scope tag IDs to Win32 app body object if they are specified.
+                If ($RoleScopeTagIDs) { $Win32AppBody.Add("roleScopeTagIds", $RoleScopeTagIDs) }
 
                 # Create the Win32 app
                 Write-Verbose -Message "Attempting to create Win32 app using constructed body converted to JSON content"

--- a/Public/Add-IntuneWin32App.ps1
+++ b/Public/Add-IntuneWin32App.ps1
@@ -502,3 +502,4 @@ function Add-IntuneWin32App {
         }
     }
 }
+


### PR DESCRIPTION
This is the first real pull request I've ever done, so I apologize if there are any issues with how I'm going about it. Please let me know if there are and I'll try to fix them.

---

This pull request does two things. We've had this only internal / local for a while and I just forked and added the changes to said fork so that I could make this PR.

### Add-IntuneWin32App RoleScopeTagIDs parameter

We had to add this parameter to Add-IntuneWin32App to make it work for our site, as without specifying a scope tag in the body that we have access to, the Graph API will reject the new app. This property is only available through the beta API (which IntuneWin32App already uses so no issue there) and originates from the [mobileApp](https://learn.microsoft.com/en-us/graph/api/resources/intune-shared-mobileapp?view=graph-rest-beta#properties) resource which [win32LobApp](https://learn.microsoft.com/en-us/graph/api/resources/intune-apps-win32lobapp?view=graph-rest-beta#properties) inherits from.

### Fix displaying Graph API error messages on PowerShell Core

On the way to figuring out that we needed the roleScopeTagIds property in the JSON, we found that IntuneWin32App doesn't show Graph API error responses on PowerShell Core, due to changes in how exceptions work. Two private functions, Invoke-AzureADGraphRequest and Invoke-IntuneGraphRequest, had switch statements added to capture the response body with methods appropriate for the edition of PowerShell that is running.

We're unsure if other functions could benefit from a similar change, as these were the only two of interest while trying to figure out why Add-IntuneWin32App wasn't working for us.