### PR TITLE
Add feature to remove specific assignments from a Win32App

### DIFF
--- a/Public/Remove-IntuneWin32AppAssignment.ps1
+++ b/Public/Remove-IntuneWin32AppAssignment.ps1
@@ -12,16 +12,20 @@ function Remove-IntuneWin32AppAssignment {
     .PARAMETER ID
         Specify the ID for a Win32 application.
 
+    .PARAMETER GroupID
+        Specify the Group ID of the assignment you wish to remove. If empty, all assignments will be removed.
+
     .NOTES
         Author:      Nickolaj Andersen
         Contact:     @NickolajA
         Created:     2020-04-29
-        Updated:     2021-08-31
+        Updated:     2023-01-23
 
         Version history:
         1.0.0 - (2020-04-29) Function created
         1.0.1 - (2021-04-01) Updated token expired message to a warning instead of verbose output
         1.0.2 - (2021-08-31) Updated to use new authentication header
+        1.0.3 - (2023-01-23) Updated to allow specific group assignments to be removed
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
@@ -31,7 +35,11 @@ function Remove-IntuneWin32AppAssignment {
 
         [parameter(Mandatory = $true, ParameterSetName = "ID", HelpMessage = "Specify the ID for a Win32 application.")]
         [ValidateNotNullOrEmpty()]
-        [string]$ID      
+        [string]$ID,      
+
+        [parameter(Mandatory = $false, HelpMessage = "Specify the Group ID of the assignment you wish to remove. If empty, all assignments will be removed.")]
+        [ValidateNotNullOrEmpty()]
+        [string]$GroupID      
     )
     Begin {
         # Ensure required authentication header variable exists
@@ -85,28 +93,38 @@ function Remove-IntuneWin32AppAssignment {
                 # Attempt to call Graph and retrieve all assignments for Win32 app
                 $Win32AppAssignmentResponse = Invoke-IntuneGraphRequest -APIVersion "Beta" -Resource "mobileApps/$($Win32AppID)/assignments" -Method "GET" -ErrorAction Stop
                 if ($Win32AppAssignmentResponse.value -ne $null) {
-                    Write-Verbose -Message "Count of assignments for Win32 app before attempted removal process: $(($Win32AppAssignmentResponse.value | Measure-Object).Count)"
+                    $AssignmentCountBefore = ($Win32AppAssignmentResponse.value | Measure-Object).Count
+                    Write-Verbose -Message "Count of assignments for Win32 app before attempted removal process: $AssignmentCountBefore"
 
                     # Process each assignment for removal
                     foreach ($Win32AppAssignment in $Win32AppAssignmentResponse.value) {
-                        Write-Verbose -Message "Attempting to remove Win32 app assignment with ID: $($Win32AppAssignment.id)"
+                        #Remove if $GroupID matches the group ID of the assignment or if no $GroupID was passed into the function
+                        If($Win32AppAssignment.target.groupId -eq $GroupID -or [string]::IsNullOrEmpty($GroupID)){
+                            Write-Verbose -Message "Attempting to remove Win32 app assignment with ID: $($Win32AppAssignment.id)"
                         
-                        try {
-                            # Remove current assignment
-                            $Win32AppAssignmentRemoveResponse = Invoke-IntuneGraphRequest -APIVersion "Beta" -Resource "mobileApps/$($Win32AppID)/assignments/$($Win32AppAssignment.id)" -Method "DELETE" -ErrorAction Stop
-                        }
-                        catch [System.Exception] {
-                            Write-Warning -Message "An error occurred while retrieving Win32 app assignments for app with ID: $($Win32AppID). Error message: $($_.Exception.Message)"
+                            try {
+                                # Remove current assignment
+                                $Win32AppAssignmentRemoveResponse = Invoke-IntuneGraphRequest -APIVersion "Beta" -Resource "mobileApps/$($Win32AppID)/assignments/$($Win32AppAssignment.id)" -Method "DELETE" -ErrorAction Stop
+                            }
+                            catch [System.Exception] {
+                                Write-Warning -Message "An error occurred while retrieving Win32 app assignments for app with ID: $($Win32AppID). Error message: $($_.Exception.Message)"
+                            }
                         }
                     }
 
                     # Calculate amount of remaining assignments after attempted removal process
                     $Win32AppAssignmentResponse = Invoke-IntuneGraphRequest -APIVersion "Beta" -Resource "mobileApps/$($Win32AppID)/assignments" -Method "GET" -ErrorAction Stop
-                    Write-Verbose -Message "Count of assignments for Win32 app after attempted removal process: $(($Win32AppAssignmentResponse.value | Measure-Object).Count)"
+                    $AssignmentCountAfter = ($Win32AppAssignmentResponse.value | Measure-Object).Count
+                    Write-Verbose -Message "Count of assignments for Win32 app after attempted removal process: $AssignmentCountAfter"
                 }
                 else {
                     Write-Verbose -Message "Unable to locate any instances for removal, Win32 app does not have any existing assignments"
                 }
+
+                If($AssignmentCountBefore -eq $AssignmentCountAfter){
+                    Write-Warning -Message "The count of assignments before and after running are the same. No assignments have been removed."
+                }
+
             }
             catch [System.Exception] {
                 Write-Warning -Message "An error occurred while retrieving Win32 app assignments for app with ID: $($Win32AppID). Error message: $($_.Exception.Message)"


### PR DESCRIPTION
Hey, 

Another one for you:

An improvement to Remove-IntuneWin32AppAssignment which allows you to optionally pass a GroupID to the function so it will remove only that one assignment rather than removing all existing assignments on the App. 

If GroupID is omitted then it will continue to work how it already does, removing all assignments. 

Also changed to produce a warning should the number of assignments before and after running the function match. This felt necessary in a case where you specify a GroupID and none of the assignments match. Open to suggestions on how / if that warning works. 