### PR TITLE
Fix adding and getting app relationships

### DIFF
--- a/Private/Get-IntuneWin32AppRelationExistence.ps1
+++ b/Private/Get-IntuneWin32AppRelationExistence.ps1
@@ -1,4 +1,4 @@
-function Get-IntuneWin32AppRelation {
+function Get-IntuneWin32AppRelationExistence {
     <#
     .SYNOPSIS
         Retrieve any existing supersedence and dependency (relations) configuration from an existing Win32 application.
@@ -23,7 +23,10 @@ function Get-IntuneWin32AppRelation {
     param(
         [parameter(Mandatory = $true, HelpMessage = "Specify the ID for an existing Win32 application to retrieve relation configuration from.")]
         [ValidateNotNullOrEmpty()]
-        [string]$ID
+        [string]$ID,
+        [Parameter(Mandatory = $true, HelpMessage = "Specify the type of relationship.")]
+        [ValidateSet("Dependency", "Supersedence")]
+        [string]$Type
     )
     Begin {
         # Ensure required authentication header variable exists

--- a/Public/Add-IntuneWin32AppDependency.ps1
+++ b/Public/Add-IntuneWin32AppDependency.ps1
@@ -61,7 +61,7 @@ function Add-IntuneWin32AppDependency {
         if ($Win32App -ne $null) {
             $Win32AppID = $Win32App.id
 
-            # Check for existing supersedence relations for Win32 app, as this relationships need to be included in the update
+            # Check for existing supersedence relations for Win32 app, as these relationships need to be included in the update
             $Supersedence = Get-IntuneWin32AppSupersedence -ID $Win32AppID
 
             # Validate that Win32 app where dependency is configured, is not passed in $Dependency variable to prevent an app depending on itself

--- a/Public/Add-IntuneWin32AppDependency.ps1
+++ b/Public/Add-IntuneWin32AppDependency.ps1
@@ -67,8 +67,9 @@ function Add-IntuneWin32AppDependency {
             # Validate that Win32 app where dependency is configured, is not passed in $Dependency variable to prevent an app depending on itself
             if ($Win32AppID -notin $Dependency.targetId) {
                 $Win32AppRelationships = [ordered]@{
-                    "relationships" = @($Dependency; $Supersedence)
+                    "relationships" = $Supersedence ? @($Dependency; $Supersedence) : @($Dependency)
                 }
+
 
                 try {
                     # Attempt to call Graph and configure dependency for Win32 app

--- a/Public/Add-IntuneWin32AppSupersedence.ps1
+++ b/Public/Add-IntuneWin32AppSupersedence.ps1
@@ -62,21 +62,13 @@ function Add-IntuneWin32AppSupersedence {
         if ($Win32App -ne $null) {
             $Win32AppID = $Win32App.id
 
-            # Check for existing relations for Win32 app, supersedence and dependency configurations cannot co-exist currently
-            #$Win32AppRelations = Get-IntuneWin32AppRelation -ID $Win32AppID
-
-            #
-            # Handle existing relation items, get all relations and combine into array with new relation(s)
-            #
-
-            if ($Win32AppRelations -ne $null) {
-                
-            }
+            # Check for existing dependency relations for Win32 app, as these relationships need to be included in the update
+            $Dependencies = Get-IntuneWin32AppDependency -ID $Win32AppID
 
             # Validate that the target Win32 app where supersedence is to be configured, is not passed in $Supersedence variable to prevent target app superseding itself
             if ($Win32AppID -notin $Supersedence.targetId) {
                 $Win32AppRelationsTable = [ordered]@{
-                    "relationships" = @($Supersedence)
+                    "relationships" = @($Supersedence; $Dependencies)
                 }
 
                 try {

--- a/Public/Add-IntuneWin32AppSupersedence.ps1
+++ b/Public/Add-IntuneWin32AppSupersedence.ps1
@@ -68,7 +68,7 @@ function Add-IntuneWin32AppSupersedence {
             # Validate that the target Win32 app where supersedence is to be configured, is not passed in $Supersedence variable to prevent target app superseding itself
             if ($Win32AppID -notin $Supersedence.targetId) {
                 $Win32AppRelationsTable = [ordered]@{
-                    "relationships" = @($Supersedence; $Dependencies)
+                    "relationships" = $Dependencies ? @($Supersedence; $Dependencies) : @($Supersedence)
                 }
 
                 try {

--- a/Public/Get-IntuneWin32AppDependency.ps1
+++ b/Public/Get-IntuneWin32AppDependency.ps1
@@ -54,11 +54,7 @@ function Get-IntuneWin32AppDependency {
                 $Win32AppRelationsResponse = Invoke-IntuneGraphRequest -APIVersion "Beta" -Resource "mobileApps/$($Win32AppID)/relationships" -Method "GET" -ErrorAction Stop
 
                 # Handle return value
-                if ($Win32AppRelationsResponse.value -ne $null) {
-                    if ($Win32AppRelationsResponse.value.'@odata.type' -like "#microsoft.graph.mobileAppDependency") {
-                        return $Win32AppRelationsResponse.value
-                    }
-                }
+                $Win32AppRelationsResponse.value | Where-Object { $_.'@odata.type' -like "#microsoft.graph.mobileAppDependency" }
             }
             catch [System.Exception] {
                 Write-Warning -Message "An error occurred while retrieving supersedence configuration for Win32 app: $($Win32AppID). Error message: $($_.Exception.Message)"

--- a/Public/Get-IntuneWin32AppSupersedence.ps1
+++ b/Public/Get-IntuneWin32AppSupersedence.ps1
@@ -55,11 +55,7 @@ function Get-IntuneWin32AppSupersedence {
                 $Win32AppRelationsResponse = Invoke-IntuneGraphRequest -APIVersion "Beta" -Resource "mobileApps/$($Win32AppID)/relationships" -Method "GET" -ErrorAction Stop
 
                 # Handle return value
-                if ($Win32AppRelationsResponse.value -ne $null) {
-                    if ($Win32AppRelationsResponse.value.'@odata.type' -like "#microsoft.graph.mobileAppSupersedence") {
-                        return $Win32AppRelationsResponse.value
-                    }
-                }
+                $Win32AppRelationsResponse.value | Where-Object { $_.'@odata.type' -like "#microsoft.graph.mobileAppSupersedence" }
             }
             catch [System.Exception] {
                 Write-Warning -Message "An error occurred while retrieving supersedence configuration for Win32 app: $($Win32AppID). Error message: $($_.Exception.Message)"


### PR DESCRIPTION
There was a call to `Get-IntuneWin32AppRelationExistence` which generated a error when adding app dependencies. This PR corrects the name of the function `Get-IntuneWin32AppRelation` to `Get-IntuneWin32AppRelationExistence`.

Adding a Win32 app dependency also overwrites the supersedence relationships. I propose to retrieve the supersedence relationships and include them in the POST requests. This same issue occurs when adding supersedence relationships.

To this end I also filtered the output of `Get-Win32AppDependency` and `Get-Win32AppSupersedence` to actually only output dependency or supersedence relationships.

Fixes #80.