### PR TITLE
Incorrect intunewin filename in warning message

### DIFF
--- a/Public/New-IntuneWin32AppPackage.ps1
+++ b/Public/New-IntuneWin32AppPackage.ps1
@@ -123,7 +123,7 @@ function New-IntuneWin32AppPackage {
                                     Write-Output -InputObject $PSObject
                                 }
                                 else {
-                                    Write-Warning -Message "Unable to detect expected '$($SetupFile).intunewin' file after IntuneWinAppUtil.exe invocation"
+                                    Write-Warning -Message "Unable to detect expected '$([System.IO.Path]::GetFileNameWithoutExtension($IntuneWinAppPackage)).intunewin' file after IntuneWinAppUtil.exe invocation"
                                 }
                             }
                             else {


### PR DESCRIPTION
Display :
Unable to detect expected 'setup.intunewin' file after IntuneWinAppUtil.exe invocation" 

instead of :
Unable to detect expected 'setup.msi.intunewin' file after IntuneWinAppUtil.exe invocation