### PR TITLE
Fix: ValidateRange works not as intended because the values are strings

### DIFF
--- a/Public/Add-IntuneWin32AppAssignmentAllDevices.ps1
+++ b/Public/Add-IntuneWin32AppAssignmentAllDevices.ps1
@@ -96,17 +96,17 @@ function Add-IntuneWin32AppAssignmentAllDevices {
 
         [parameter(Mandatory = $false, HelpMessage = "Specify the device restart grace period in minutes.")]
         [ValidateNotNullOrEmpty()]
-        [ValidateRange("1", "20160")]
+        [ValidateRange(1, 20160)]
         [int]$RestartGracePeriod = 1440,
 
         [parameter(Mandatory = $false, HelpMessage = "Specify a count in minutes when the restart count down display box is shown.")]
         [ValidateNotNullOrEmpty()]
-        [ValidateRange("1", "240")]
+        [ValidateRange(1, 240)]
         [int]$RestartCountDownDisplay = 15,
         
         [parameter(Mandatory = $false, HelpMessage = "Specify a count in minutes for snoozing the restart notification, if not specified the snooze functionality is now allowed.")]
         [ValidateNotNullOrEmpty()]
-        [ValidateRange("1", "712")]
+        [ValidateRange(1, 712)]
         [int]$RestartNotificationSnooze = 240,
 
         [parameter(Mandatory = $false, HelpMessage = "Specify the name of an existing Filter.")]

--- a/Public/Add-IntuneWin32AppAssignmentAllUsers.ps1
+++ b/Public/Add-IntuneWin32AppAssignmentAllUsers.ps1
@@ -96,17 +96,17 @@ function Add-IntuneWin32AppAssignmentAllUsers {
 
         [parameter(Mandatory = $false, HelpMessage = "Specify the device restart grace period in minutes.")]
         [ValidateNotNullOrEmpty()]
-        [ValidateRange("1", "20160")]
+        [ValidateRange(1, 20160)]
         [int]$RestartGracePeriod = 1440,
 
         [parameter(Mandatory = $false, HelpMessage = "Specify a count in minutes when the restart count down display box is shown.")]
         [ValidateNotNullOrEmpty()]
-        [ValidateRange("1", "240")]
+        [ValidateRange(1, 240)]
         [int]$RestartCountDownDisplay = 15,
         
         [parameter(Mandatory = $false, HelpMessage = "Specify a count in minutes for snoozing the restart notification, if not specified the snooze functionality is now allowed.")]
         [ValidateNotNullOrEmpty()]
-        [ValidateRange("1", "712")]
+        [ValidateRange(1, 712)]
         [int]$RestartNotificationSnooze = 240,
 
         [parameter(Mandatory = $false, HelpMessage = "Specify the name of an existing Filter.")]

--- a/Public/Add-IntuneWin32AppAssignmentGroup.ps1
+++ b/Public/Add-IntuneWin32AppAssignmentGroup.ps1
@@ -120,17 +120,17 @@ function Add-IntuneWin32AppAssignmentGroup {
 
         [parameter(Mandatory = $false, ParameterSetName = "GroupInclude", HelpMessage = "Specify the device restart grace period in minutes.")]
         [ValidateNotNullOrEmpty()]
-        [ValidateRange("1", "20160")]
+        [ValidateRange(1, 20160)]
         [int]$RestartGracePeriod = 1440,
 
         [parameter(Mandatory = $false, ParameterSetName = "GroupInclude", HelpMessage = "Specify a count in minutes when the restart count down display box is shown.")]
         [ValidateNotNullOrEmpty()]
-        [ValidateRange("1", "240")]
+        [ValidateRange(1, 240)]
         [int]$RestartCountDownDisplay = 15,
         
         [parameter(Mandatory = $false, ParameterSetName = "GroupInclude", HelpMessage = "Specify a count in minutes for snoozing the restart notification, if not specified the snooze functionality is now allowed.")]
         [ValidateNotNullOrEmpty()]
-        [ValidateRange("1", "712")]
+        [ValidateRange(1, 712)]
         [int]$RestartNotificationSnooze = 240,
 
         [parameter(Mandatory = $false, ParameterSetName = "GroupInclude", HelpMessage = "Specify the name of an existing Filter.")]


### PR DESCRIPTION
# Change:
Fixed all instances where ValidateRange("$number","$number") is instead of ValidateRange($number,$number)

# Issue: 
There is an error in the notation of the validation range, which is causing issues when inputting values within that specified range.

## Example: 
``` Powershell
PS C:\Users\thoma> Add-IntuneWin32AppAssignmentGroup -EnableRestartGracePeriod $true -RestartGracePeriod 340
Add-IntuneWin32AppAssignmentGroup : Cannot validate argument on parameter 'RestartGracePeriod'. The 340 argument is greater than the maximum allowed range of 20160. 
Supply an argument that is less than or equal to 20160 and then try the command again.
At line:1 char:87
+ ... signmentGroup -EnableRestartGracePeriod $true -RestartGracePeriod 340
+                                                                       ~~~
    + CategoryInfo          : InvalidData: (:) [Add-IntuneWin32AppAssignmentGroup], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationError,Add-IntuneWin32AppAssignmentGroup
```
For example RestartGracePeriod 340. 
340 is a valid input because 1<340<20160
But because the ValidateRange is incorrect powershell rejects it with the error that 340 (number) is bigger then 20160 (string)

