### PR TITLE
Remove-IntuneWin32AppSupersedence - Relationships needs to be a array

### DIFF
--- a/Public/Remove-IntuneWin32AppSupersedence.ps1
+++ b/Public/Remove-IntuneWin32AppSupersedence.ps1
@@ -52,7 +52,7 @@ function Remove-IntuneWin32AppSupersedence {
 
             # Create relationships table using ternary conditional expression to handle potential empty dependencies relations
             $Win32AppRelationshipsTable = [ordered]@{
-                "relationships" = if ($Dependencies) { @($Dependencies) } else { $() }
+                "relationships" = @($Dependencies)
             }
 
             try {


### PR DESCRIPTION
When no dependencies are found in a Win32App, I think we need to change $win32AppRelationshipsTable from: 
```
{
    "relationships":  null
}

```
to 
```
{
    "relationships":  []
}
```


Without the change I get:

> ADVERTENCIA: An error occurred while removing supersedence configuration for Win32 app: 375fcc3b-eee8-44f3-8956-8b8d489151c0. Error message: BadRequest: {
>   "Message": "Invalid action parameter: 'relationships'. - Operation ID (for customer support): 00000000-0000-0000-0000-000000000000 - Activity ID: b8232255-78e2-4c1a-af96-83a811c575ec - Url:
> https://fef.msub06.manage.microsoft.com/AppLifecycle_2402/StatelessAppMetadataFEService/deviceAppManagement/mobileApps('375fcc3b-eee8-44f3-8956-8b8d489151c0')/microsoft.management.services.api.updateRelations hips?api-version=5023-11-15",
>   "RetryAfter": null,
>   "ErrorSourceService": "",
>   "HttpHeaders": "{}"
> 

I did not check, but may be we can do the same change with Remove-IntuneWin32AppDependency