### PR TITLE
Updates fix issues with Relationship.

### DIFF
--- a/Private/ConvertTo-Hashtable.ps1
+++ b/Private/ConvertTo-Hashtable.ps1
@@ -1,0 +1,38 @@
+# Borrowed from mrpullen on github
+
+function ConvertTo-Hashtable
+{
+    param (
+        [Parameter(ValueFromPipeline)]
+        $InputObject
+    )
+
+    process
+    {
+        if ($null -eq $InputObject) { return $null }
+
+        if ($InputObject -is [System.Collections.IEnumerable] -and $InputObject -isnot [string])
+        {
+            $collection = @(
+                foreach ($object in $InputObject) { Convertto-Hashtable $object }
+            )
+
+            Write-Output -NoEnumerate $collection
+        }
+        elseif ($InputObject -is [psobject])
+        {
+            $hash = [ordered]@{}
+
+            foreach ($property in $InputObject.PSObject.Properties)
+            {
+                $hash[$property.Name] = ConvertTo-Hashtable $property.Value
+            }
+
+            $hash
+        }
+        else
+        {
+            $InputObject
+        }
+    }
+}

--- a/Private/ConvertTo-IntuneWin32RelationshipJSON.ps1
+++ b/Private/ConvertTo-IntuneWin32RelationshipJSON.ps1
@@ -1,0 +1,51 @@
+function ConvertTo-IntuneWin32RelationshipJSON {
+    <#
+    .SYNOPSIS
+        Combine supersedence and dependancy into a valid JSON, dealing with the edge cases of 0 and 1 that create 
+        "incorrect" JSON using the standard JSON conversion according to the MS API's
+        
+    .DESCRIPTION
+        Combine supersedence and dependancy into a valid JSON, dealing with the edge cases of 0 and 1 that create 
+        "incorrect" JSON using the standard JSON conversion according to the MS API's
+
+    .PARAMETER ID
+        Specify the ID for an existing Win32 application where supersedence will be configured.
+
+    .PARAMETER Supersedence
+        Provide an array of a single or multiple OrderedDictionary objects created with New-IntuneWin32AppSupersedence function.
+
+    .PARAMETER Dependency
+        Provide an array of a single or multiple OrderedDictionary objects created with New-IntuneWin32AppDependency function.
+
+
+    .NOTES
+        Author:      Chris Cobb
+        Contact:     @crcobb
+        Created:     2024-01-29
+        Updated:     2023-01-29
+
+        Version history:
+        1.0.0 - (2024-01-29) Function created
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param(
+        [parameter(Mandatory = $true, HelpMessage = "Provide an array of a single or multiple OrderedDictionary objects created with New-IntuneWin32AppSupersedence function.")]
+        [AllowEmptyCollection()]
+        [AllowNull()]
+        [System.Collections.Specialized.OrderedDictionary[]]$Supersedence,
+
+        [parameter(Mandatory = $true, HelpMessage = "Provide an array of a single or multiple OrderedDictionary objects created with New-IntuneWin32AppDependency function.")]
+        [AllowEmptyCollection()]
+        [AllowNull()]
+        [System.Collections.Specialized.OrderedDictionary[]]$Dependency
+    )
+    $Win32AppRelationshipsTable = @()
+    if ($Supersedence) { $Win32AppRelationshipsTable += @($Supersedence) } 
+    if ($Dependency) { $Win32AppRelationshipsTable += @($Dependency) } 
+    
+    $JSON = ConvertTo-Json -InputObject @($Win32AppRelationshipsTable)
+    if( $null -eq $Win32AppRelationshipsTable ) { $JSON = $JSON.Replace( "null", "[ ]")}
+    $JSON = "{ ""relationships"": $($JSON) }" 
+    
+    return $JSON
+}

--- a/Private/Invoke-Executable.ps1
+++ b/Private/Invoke-Executable.ps1
@@ -10,16 +10,28 @@ function Invoke-Executable {
 
         [parameter(Mandatory = $false, HelpMessage = "Specify whether standard output should be redirected.")]
         [ValidateNotNull()]
-        [bool]$RedirectStandardOutput = $true
+        [bool]$RedirectStandardOutput = $true,
+
+        [parameter(Mandatory = $false, HelpMessage = "Specify whether standard error output should be redirected.")]
+        [ValidateNotNull()]
+        [bool]$RedirectStandardError = $true,
+
+        [parameter(Mandatory = $false, HelpMessage = "Specify whether to create a new window for the executable.")]
+        [ValidateNotNull()]
+        [bool]$CreateNoWindow = $true,
+
+        [parameter(Mandatory = $false, HelpMessage = "Specify whether to create a new window for the executable.")]
+        [ValidateNotNull()]
+        [bool]$UseShellExecute = $false
     )
     try {
         # Create the Process Info object which contains details about the process
-        $ProcessStartInfoObject = New-object System.Diagnostics.ProcessStartInfo 
+        $ProcessStartInfoObject = New-object -TypeName "System.Diagnostics.ProcessStartInfo"
         $ProcessStartInfoObject.FileName = $FilePath
-        $ProcessStartInfoObject.CreateNoWindow = $true 
-        $ProcessStartInfoObject.UseShellExecute = $false 
+        $ProcessStartInfoObject.CreateNoWindow = $CreateNoWindow
+        $ProcessStartInfoObject.UseShellExecute = $UseShellExecute
         $ProcessStartInfoObject.RedirectStandardOutput = $RedirectStandardOutput
-        $ProcessStartInfoObject.RedirectStandardError = $true 
+        $ProcessStartInfoObject.RedirectStandardError = $RedirectStandardError 
         
         # Add the arguments to the process info object
         if ($Arguments.Count -gt 0) {

--- a/Private/Test-IntuneWin32AppAssignment.ps1
+++ b/Private/Test-IntuneWin32AppAssignment.ps1
@@ -12,6 +12,9 @@ function Test-IntuneWin32AppAssignment {
     .PARAMETER Target
         Specify the target type of the assignment, AllDevices, AllUsers or Group.
 
+    .PARAMETER Intent
+        Specify the intent of the assignment, either required, available or uninstall.
+    
     .NOTES
         Author:      Nickolaj Andersen
         Contact:     @NickolajA
@@ -30,7 +33,12 @@ function Test-IntuneWin32AppAssignment {
         [parameter(Mandatory = $false, HelpMessage = "Specify the target type of the assignment, AllDevices, AllUsers or Group.")]
         [ValidateNotNullOrEmpty()]
         [ValidateSet("AllDevices", "AllUsers", "Group")]
-        [string]$Target
+        [string]$Target,
+
+        [parameter(Mandatory = $false, HelpMessage = "Specify the intent of the assignment, either required, available or uninstall.")]
+        [ValidateSet("required", "available", "uninstall")]
+        [string]$Intent = $null
+
     )
     Process {
         # Handle initial value for duplicate assignment
@@ -57,9 +65,9 @@ function Test-IntuneWin32AppAssignment {
                 switch ($Target) {
                     "Group" {
                         foreach ($Win32AppAssignment in $Win32AppAssignments.value) {
-                            if ($Win32AppAssignment.target.'@odata.type' -match "groupAssignmentTarget") {
+                            if ($Win32AppAssignment.target.'@odata.type' -match "groupAssignmentTarget" -and (($null -eq $Intent) -or ($intent -eq $Win32AppAssignment.Intent))) {
                                 if ($Win32AppAssignment.target.groupId -like $GroupID) {
-                                    Write-Warning -Message "Win32 app assignment with id '$($Win32AppAssignment.id)' of target type '$($Target)' and GroupID '$($Win32AppAssignment.target.groupId)' already exists, duplicate assignments of this type is not permitted"
+                                    Write-Warning -Message "Win32 app assignment with id '$($Win32AppAssignment.id)' of target type '$($Target)' and GroupID '$($Win32AppAssignment.target.groupId)' with Intent '$($Intent)' already exists, duplicate assignments of this type is not permitted"
                                     $DuplicateAssignmentDetected = $true
                                 }
                             }

--- a/Public/Add-IntuneWin32AppAssignmentGroup.ps1
+++ b/Public/Add-IntuneWin32AppAssignmentGroup.ps1
@@ -313,7 +313,7 @@ function Add-IntuneWin32AppAssignmentGroup {
                 }
             }
 
-            $DuplicateAssignment = Test-IntuneWin32AppAssignment -ID $Win32AppID -Target "Group"
+            $DuplicateAssignment = Test-IntuneWin32AppAssignment -ID $Win32AppID -Target "Group" -Intent $Intent
             if ($DuplicateAssignment -eq $false) {
                 try {
                     # Attempt to call Graph and create new assignment for Win32 app

--- a/Public/Add-IntuneWin32AppSupersedence.ps1
+++ b/Public/Add-IntuneWin32AppSupersedence.ps1
@@ -65,13 +65,15 @@ function Add-IntuneWin32AppSupersedence {
             # Validate that the target Win32 app where supersedence is to be configured, is not passed in $Supersedence variable to prevent target app superseding itself
             if ($Win32AppID -notin $Supersedence.targetId) {
                 @($Supersedence; $Dependencies)
-                $Win32AppRelationshipsTable = [ordered]@{
-                    "relationships" = if ($Dependencies) { @($Supersedence; $Dependencies) } else { @($Supersedence) }
-                }
+                $Win32AppRelationshipsTable = [ordered]@{"relationships" = if ($Dependencies) { @($Supersedence; $Dependencies) } else { @($Supersedence) } }
+                $Win32AppRelationshipsTable_test = if ($Dependencies) { @($Supersedence; $Dependencies) } else { @($Supersedence) }
+                $Win32AppRelationshipsTable_JSON = ConvertTo-Json -InputObject @($Win32AppRelationshipsTable_test)
+                $Win32AppRelationshipsTable_JSON =  "{ ""relationships"": $($Win32AppRelationshipsTable_JSON) }" 
+                
 
                 try {
                     # Attempt to call Graph and configure supersedence for Win32 app
-                    Invoke-IntuneGraphRequest -APIVersion "Beta" -Resource "mobileApps/$($Win32AppID)/updateRelationships" -Method "POST" -Body ($Win32AppRelationshipsTable | ConvertTo-Json) -ErrorAction Stop
+                    Invoke-IntuneGraphRequest -APIVersion "Beta" -Resource "mobileApps/$($Win32AppID)/updateRelationships" -Method "POST" -Body ($Win32AppRelationshipsTable_JSON) -ErrorAction Stop
                 }
                 catch [System.Exception] {
                     Write-Warning -Message "An error occurred while configuring supersedence for Win32 app: $($Win32AppID). Error message: $($_.Exception.Message)"

--- a/Public/Add-IntuneWin32AppSupersedence.ps1
+++ b/Public/Add-IntuneWin32AppSupersedence.ps1
@@ -30,7 +30,8 @@ function Add-IntuneWin32AppSupersedence {
         [string]$ID,
         
         [parameter(Mandatory = $true, HelpMessage = "Provide an array of a single or multiple OrderedDictionary objects created with New-IntuneWin32AppSupersedence function.")]
-        [ValidateNotNullOrEmpty()]
+        [AllowEmptyCollection()]
+        [AllowNull()]
         [System.Collections.Specialized.OrderedDictionary[]]$Supersedence
     )
     Begin {
@@ -61,15 +62,11 @@ function Add-IntuneWin32AppSupersedence {
 
             # Check for existing dependency relations for Win32 app, as these relationships need to be included in the update
             $Dependencies = Get-IntuneWin32AppDependency -ID $Win32AppID
-
+            
             # Validate that the target Win32 app where supersedence is to be configured, is not passed in $Supersedence variable to prevent target app superseding itself
             if ($Win32AppID -notin $Supersedence.targetId) {
-                @($Supersedence; $Dependencies)
-                $Win32AppRelationshipsTable = [ordered]@{"relationships" = if ($Dependencies) { @($Supersedence; $Dependencies) } else { @($Supersedence) } }
-                $Win32AppRelationshipsTable_test = if ($Dependencies) { @($Supersedence; $Dependencies) } else { @($Supersedence) }
-                $Win32AppRelationshipsTable_JSON = ConvertTo-Json -InputObject @($Win32AppRelationshipsTable_test)
-                $Win32AppRelationshipsTable_JSON =  "{ ""relationships"": $($Win32AppRelationshipsTable_JSON) }" 
-                
+ 
+                $Win32AppRelationshipsTable_JSON = ConvertTo-IntuneWin32RelationshipJSON -Supersedence @($Supersedence) -Dependency @($Dependencies)
 
                 try {
                     # Attempt to call Graph and configure supersedence for Win32 app

--- a/Public/New-IntuneWin32AppDependency.ps1
+++ b/Public/New-IntuneWin32AppDependency.ps1
@@ -39,7 +39,7 @@ function New-IntuneWin32AppDependency {
             Write-Warning -Message "Authentication token was not found, use Connect-MSIntuneGraph before using this function"; break
         }
         else {
-            if (Test-AccessToken -eq $false) {
+            if ((Test-AccessToken) -eq $false) {
                 Write-Warning -Message "Existing token found but has expired, use Connect-MSIntuneGraph to request a new authentication token"; break
             }
         }

--- a/Public/New-IntuneWin32AppPackage.ps1
+++ b/Public/New-IntuneWin32AppPackage.ps1
@@ -102,7 +102,7 @@ function New-IntuneWin32AppPackage {
                         if ($ProcessPackage -eq $true) {
                             # Invoke IntuneWinAppUtil.exe with parameter inputs
                             Write-Verbose -Message "Invoking IntuneWinAppUtil.exe to initialize packaging process"
-                            $PackageInvocation = Invoke-Executable -FilePath $IntuneWinAppUtilPath -Arguments "-c ""$($SourceFolder)"" -s ""$($SetupFile)"" -o ""$($OutPutFolder)"" -q" -RedirectStandardOutput $false
+                            $PackageInvocation = Invoke-Executable -FilePath $IntuneWinAppUtilPath -Arguments "-c ""$($SourceFolder)"" -s ""$($SetupFile)"" -o ""$($OutPutFolder)"" -q" -RedirectStandardOutput $false -RedirectStandardError $false -CreateNoWindow $false -UseShellExecute $true
                             if ($PackageInvocation.ExitCode -eq 0) {
                                 Write-Verbose -Message "IntuneWinAppUtil.exe packaging process completed with exit code $($PackageInvocation.ExitCode)"
 


### PR DESCRIPTION
##### Added Functions
1.  Added private function ConvertTo-Hashtable to take an unordered PSObject and return an [ordered] object.  Used so that Get-IntuneWin32AppDependency and Get-IntuneWin32AppSupersedence could return an [ordered] object arry since you need this type of object to call the Set- version of these commands.
1. Added private function ConvertTo-IntuneWin32RelationshipJSON.  When working with Supersedence and Dependencies if you wanted to assign a single Supersedence or no Supersedence (same with Dependencies) the standard ConvertTo-JSON would create JSON that the Graph API wouldn't accept.  This is my attempt to deal with these edge cases.
A relationship object with no relationships would be created as
```
{
  "relationships": null
}
```
The API's are looking for 
```

{ "relationships" : [  ] }

```
A relationship object with a single relationships was created by ConvertTo-JSON as
```
{
    "relationships":  {
                          "@odata.type":  "#microsoft.graph.mobileAppSupersedence",
                          "supersedenceType":  "update",
                          "targetId":  "c5944f4d-4434-4b3a-a933-3b92158f1ce9"
                      }
}
```
The API's are lookiung for this format
```
{ "relationships": [
    {
        "@odata.type":  "#microsoft.graph.mobileAppSupersedence",
        "supersedenceType":  "update",
        "targetId":  "c5944f4d-4434-4b3a-a933-3b92158f1ce9"
    }
] }
```

### Updates to Add-IntuneWin32ppDependency
1. Allowed the passing a empty $Dependency, this allow this function to remove all Dependencies.
1. Fixed the logic for pulling current supercedence.  You can only update the supersedence with "child" relationships.
1. Fixed the edge case for JSON conversion of single items.

### Updates to Add-IntuneWin32AppSupersedence
1. Allowed the passing a empty $Supersedence, this allow this function to remove all Supersedences.
1. Fixed the edge case for JSON conversion of single items.

### Updates to Get-IntuneWin32ppDependency
1. Return Dependency as an array of [ordered].  Should be in the same format as required by the Set function.
1. Fixed the logic to deal with multiple dependancies.

### Updates to Get-IntuneWin32AppSupersedence
1. Added a switch for -ChildOnly to return just the child supersedence.  This is useful when updating supersedence.
1. Return Supersedence as an array of [ordered].  Should be in the same format as required by the Set function.

### Updates to New-IntuneWin32AppDependency
1. Fixed syntax error

### Updates to Remove-IntuneWin32App
1. Added -Force switch to allow removal of app with dependancies or supersedences.  It will remove all child and parent supersedences and dependencies.

### Updates to Remove-IntuneWIn32AppDependency
1. Updated to fix JSON edge cases

### Updates to Remove-IntuneWIn32AppSupersedence
1. Updated to fix JSON edge cases
