### PR TITLE
Fixed a bug with Test-IntuneWin32AppAssignment. 

### DIFF
--- a/Private/Test-IntuneWin32AppAssignment.ps1
+++ b/Private/Test-IntuneWin32AppAssignment.ps1
@@ -27,6 +27,10 @@ function Test-IntuneWin32AppAssignment {
         [ValidateNotNullOrEmpty()]
         [string]$ID,
 
+        [parameter(Mandatory = $false, HelpMessage = "Specify the DataType in this assignment")]
+        [ValidateNotNullOrEmpty()]
+        [string]$DataType,
+
         [parameter(Mandatory = $false, HelpMessage = "Specify the target type of the assignment, AllDevices, AllUsers or Group.")]
         [ValidateNotNullOrEmpty()]
         [ValidateSet("AllDevices", "AllUsers", "Group")]
@@ -57,7 +61,7 @@ function Test-IntuneWin32AppAssignment {
                 switch ($Target) {
                     "Group" {
                         foreach ($Win32AppAssignment in $Win32AppAssignments.value) {
-                            if ($Win32AppAssignment.target.'@odata.type' -match "groupAssignmentTarget") {
+                            if ($Win32AppAssignment.target.'@odata.type' -eq $DataType) {
                                 if ($Win32AppAssignment.target.groupId -like $GroupID) {
                                     Write-Warning -Message "Win32 app assignment with id '$($Win32AppAssignment.id)' of target type '$($Target)' and GroupID '$($Win32AppAssignment.target.groupId)' already exists, duplicate assignments of this type is not permitted"
                                     $DuplicateAssignmentDetected = $true

--- a/Public/Add-IntuneWin32AppAssignmentGroup.ps1
+++ b/Public/Add-IntuneWin32AppAssignmentGroup.ps1
@@ -313,7 +313,7 @@ function Add-IntuneWin32AppAssignmentGroup {
                 }
             }
 
-            $DuplicateAssignment = Test-IntuneWin32AppAssignment -ID $Win32AppID -Target "Group"
+            $DuplicateAssignment = Test-IntuneWin32AppAssignment -ID $Win32AppID -Target "Group" -DataType $DataType
             if ($DuplicateAssignment -eq $false) {
                 try {
                     # Attempt to call Graph and create new assignment for Win32 app


### PR DESCRIPTION
It would not take DataType into consideration when checking group duplication.

Ran into this issue when having a group for Include/Install, and then using the same group for Exclude/Uninstall.
Would be nice to have this published as a new release so it can be used without having to use my own forked module everywhere.