### PR TITLE
Add DetectionRule parameter to `Set-IntuneWin32App`

### DIFF
--- a/IntuneWin32App.psd1
+++ b/IntuneWin32App.psd1
@@ -11,7 +11,7 @@
 RootModule = 'IntuneWin32App.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.4.4'
+ModuleVersion = '1.4.5'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Public/Set-IntuneWin32App.ps1
+++ b/Public/Set-IntuneWin32App.ps1
@@ -39,16 +39,24 @@ function Set-IntuneWin32App {
     .PARAMETER CompanyPortalFeaturedApp
         Specify whether to have the Win32 application featured in Company Portal or not.
 
+    .PARAMETER AllowAvailableUninstall
+        Specify whether to allow the Win32 application to be uninstalled from the Company Portal app when assigned as available.
+
+    .PARAMETER DetectionRule
+        Provide an array of a single or multiple OrderedDictionary objects as detection rules that will be used for the Win32 application.
+
     .NOTES
         Author:      Nickolaj Andersen
+        Updated by:  Onni Rautanen
         Contact:     @NickolajA
         Created:     2023-01-25
-        Updated:     2023-09-04
+        Updated:     2025-06-26
 
         Version history:
         1.0.0 - (2023-01-25) Function created
         1.0.1 - (2023-03-17) Added AllowAvailableUninstall parameter switch.
         1.0.2 - (2023-09-04) Updated with Test-AccessToken function
+        1.4.5 - (2025-06-26) Added DetectionRule parameter for updating detection rules
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
@@ -96,7 +104,11 @@ function Set-IntuneWin32App {
         [bool]$CompanyPortalFeaturedApp,
 
         [parameter(Mandatory = $false, HelpMessage = "Specify whether to allow the Win32 application to be uninstalled from the Company Portal app when assigned as available.")]
-        [bool]$AllowAvailableUninstall
+        [bool]$AllowAvailableUninstall,
+
+        [parameter(Mandatory = $false, HelpMessage = "Provide an array of a single or multiple OrderedDictionary objects as detection rules that will be used for the Win32 application.")]
+        [ValidateNotNullOrEmpty()]
+        [System.Collections.Specialized.OrderedDictionary[]]$DetectionRule
     )
     Begin {
         # Ensure required authentication header variable exists
@@ -157,6 +169,11 @@ function Set-IntuneWin32App {
             }
             if ($PSBoundParameters["AllowAvailableUninstall"]) {
                 $Win32AppBody.Add("allowAvailableUninstall", $AllowAvailableUninstall)
+            }
+
+            # Handle detection rules
+            if ($PSBoundParameters["DetectionRule"]) {
+                $Win32AppBody.Add("detectionRules", $DetectionRule)
             }
 
             try {

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,8 @@
 # Release notes for IntuneWin32App module
 
+## 1.4.5
+- Added DetectionRule parameter to `Set-IntuneWin32App` function to support updating detection rules for existing Win32 applications.
+
 ## 1.4.4
 - Improved handling of empty object references in functions `Remove-IntuneWin32AppSupersedence` and `Remove-IntuneWin32AppDependency` functions that would render a null value to be added in the JSON construct instead of `[]`.
 - Function `New-IntuneWin32AppPackage` function should now work better as for it's enforced output that it doesn't like when attempted to be hidden.


### PR DESCRIPTION
Add DetectionRule parameter to `Set-IntuneWin32App` function to support updating detection rules for existing Win32 applications.