### PR TITLE
Add ARM64 architecture support for Win32 app requirements

### DIFF
--- a/Private/New-IntuneWin32AppBody.ps1
+++ b/Private/New-IntuneWin32AppBody.ps1
@@ -271,7 +271,7 @@ function New-IntuneWin32AppBody {
         $MinimumSupportedWindowsRelease = $RequirementRule["minimumSupportedWindowsRelease"]
     }
     else {
-        $ApplicableArchitectures = "x64,x86"
+        $ApplicableArchitectures = "x64,x86,arm64"
         $MinimumSupportedWindowsRelease = "2H20"
     }
 

--- a/Public/New-IntuneWin32AppRequirementRule.ps1
+++ b/Public/New-IntuneWin32AppRequirementRule.ps1
@@ -43,7 +43,7 @@ function New-IntuneWin32AppRequirementRule {
     param(
         [parameter(Mandatory = $true, HelpMessage = "Specify the architecture as a requirement for the Win32 app.")]
         [ValidateNotNullOrEmpty()]
-        [ValidateSet("x64", "x86", "All")]
+        [ValidateSet("x64", "x86", "arm64", "All")]
         [string]$Architecture,
 
         [parameter(Mandatory = $true, HelpMessage = "Specify the minimum supported Windows release version as a requirement for the Win32 app.")]
@@ -73,7 +73,8 @@ function New-IntuneWin32AppRequirementRule {
         $ArchitectureTable = @{
             "x64" = "x64"
             "x86" = "x86"
-            "All" = "x64,x86"
+            "arm64" = "arm64"
+            "All" = "x64,x86,arm64"
         }
 
         # Construct table for supported operating systems


### PR DESCRIPTION
This PR adds support for ARM64 architecture in Win32 app requirement rules.

## Changes Made
- Added 'arm64' to the ValidateSet in New-IntuneWin32AppRequirementRule function
- Updated ArchitectureTable to include arm64 mapping
- Updated 'All' architecture to include x64,x86,arm64 
- Updated default ApplicableArchitectures to include arm64

## Background
With the increasing adoption of ARM64 Windows devices (Surface Pro X, Surface Laptop SE, and other ARM-based Windows devices), it's important that Intune Win32 apps can properly target ARM64 architecture.

## Testing
- Tested with Microsoft Intune in production environment
- Verified that ARM64 apps can be deployed with proper architecture requirements
- Confirmed backward compatibility with existing x64/x86 deployments

This enables proper deployment of Win32 apps to ARM64 Windows devices through Microsoft Intune, addressing the growing need for ARM64 support in enterprise environments.