### PR TITLE
Fix Locale-specific DateTime Parsing issue

### DIFF
--- a/Private/Invoke-AzureStorageBlobUpload.ps1
+++ b/Private/Invoke-AzureStorageBlobUpload.ps1
@@ -58,7 +58,7 @@ function Invoke-AzureStorageBlobUpload {
 
         # Convert ExpiresOn to DateTimeOffset in UTC
         $ExpiresOnUTC = [DateTimeOffset]::Parse(
-            $Global:AccessToken.ExpiresOn.ToString(),
+            $Global:AccessToken.ExpiresOn.ToString([System.Globalization.CultureInfo]::InvariantCulture),
             [System.Globalization.CultureInfo]::InvariantCulture,
             [System.Globalization.DateTimeStyles]::AssumeUniversal
             ).ToUniversalTime()

--- a/Public/New-IntuneWin32AppRequirementRule.ps1
+++ b/Public/New-IntuneWin32AppRequirementRule.ps1
@@ -55,7 +55,7 @@ function New-IntuneWin32AppRequirementRule {
 
         [parameter(Mandatory = $true, HelpMessage = "Specify the minimum supported Windows release version as a requirement for the Win32 app.")]
         [ValidateNotNullOrEmpty()]
-        [ValidateSet("W10_1607", "W10_1703", "W10_1709", "W10_1803", "W10_1809", "W10_1903", "W10_1909", "W10_2004", "W10_20H2", "W10_21H1", "W10_21H2", "W10_22H2", "W11_21H2", "W11_22H2")]
+        [ValidateSet("W10_1607", "W10_1703", "W10_1709", "W10_1803", "W10_1809", "W10_1903", "W10_1909", "W10_2004", "W10_20H2", "W10_21H1", "W10_21H2", "W10_22H2", "W11_21H2", "W11_22H2", "W11_23H2", "W11_24H2")]
         [Alias('MinimumSupportedOperatingSystem')]
         [string]$MinimumSupportedWindowsRelease,
 
@@ -101,6 +101,8 @@ function New-IntuneWin32AppRequirementRule {
             "W10_22H2" = "Windows10_22H2"
             "W11_21H2" = "Windows11_21H2"
             "W11_22H2" = "Windows11_22H2"
+            "W11_23H2" = "Windows11_23H2"
+            "W11_24H2" = "Windows11_24H2"
         }
 
         # Construct ordered hash-table with least amount of required properties for default requirement rule

--- a/Public/Test-AccessToken.ps1
+++ b/Public/Test-AccessToken.ps1
@@ -46,7 +46,7 @@ function Test-AccessToken {
             }
 
             # Convert ExpiresOn to DateTimeOffset in UTC
-            $ExpiresOnUTC = [DateTimeOffset]::Parse($Global:AccessToken.ExpiresOn.ToString(), [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal).ToUniversalTime()
+            $ExpiresOnUTC = [DateTimeOffset]::Parse($Global:AccessToken.ExpiresOn.ToString([System.Globalization.CultureInfo]::InvariantCulture), [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AssumeUniversal).ToUniversalTime()
 
             # Get the current UTC time as DateTimeOffset
             $UTCDateTime = [DateTimeOffset]::UtcNow


### PR DESCRIPTION
## Problem
Currently fails on some non-US systems due to locale-specific date parsing. Users in UK, Australia, Netherlands, and other DD/MM/YYYY format regions encounter:
Exception calling "Parse" with "3" argument(s): "String '26/01/2026 15:39:11' was not recognized as a valid DateTime"

## Root Cause
The code uses `ExpiresOn.ToString()` which outputs in system locale format, but the parser expects invariant culture (MM/DD/YYYY) format.
 
## Solution
Added `[System.Globalization.CultureInfo]::InvariantCulture` parameter to `ToString()` calls in:
- [Private/Invoke-AzureStorageBlobUpload.ps1](cci:7://file:///c:/GIT/IntuneWin32App/Private/Invoke-AzureStorageBlobUpload.ps1:0:0-0:0)
- [Public/Test-AccessToken.ps1](cci:7://file:///c:/GIT/IntuneWin32App/Public/Test-AccessToken.ps1:0:0-0:0)
 
This ensures consistent date formatting regardless of user's regional settings.
 
## Impact
- Fixes issue for some non-US users
 
## Testing
Confirmed working on UK \ NL \ DE configured systems - resolves the parsing error while maintaining functionality for US users.
 
Fixes #210