### PR TITLE
Fix SAS renewal: use Resource as-is to avoid double deviceAppManagement segment

### DIFF
--- a/Private/Invoke-AzureStorageBlobUploadRenew.ps1
+++ b/Private/Invoke-AzureStorageBlobUploadRenew.ps1
@@ -25,7 +25,7 @@ function Invoke-AzureStorageBlobUploadRenew {
         [ValidateNotNullOrEmpty()]
         [string]$Resource
     )
-    $RenewSASURIRequest = Invoke-MSGraphOperation -Post -APIVersion "Beta" -Resource "deviceAppManagement/$($Resource)/renewUpload" -Body "{}"
+    $RenewSASURIRequest = Invoke-MSGraphOperation -Post -APIVersion "Beta" -Resource "$($Resource)/renewUpload" -Body "{}"
 
     # Loop to wait for the renewal process to complete and check the status
     $attempts = 0
@@ -33,7 +33,7 @@ function Invoke-AzureStorageBlobUploadRenew {
     $waitTime = 5 # seconds
 
     while ($attempts -lt $maxAttempts) {
-        $FilesProcessingRequest = Invoke-MSGraphOperation -Get -APIVersion "Beta" -Resource "deviceAppManagement/$($Resource)"
+        $FilesProcessingRequest = Invoke-MSGraphOperation -Get -APIVersion "Beta" -Resource $Resource
         if ($FilesProcessingRequest.uploadState -eq "azureStorageUriRenewalSuccess") {
             return $FilesProcessingRequest.azureStorageUri
         } elseif ($FilesProcessingRequest.uploadState -eq "azureStorageUriRenewalFailed") {


### PR DESCRIPTION
## Problem

When uploading large Win32 apps (e.g. >2 GB, many chunks), SAS URI renewal fails after ~7–15 minutes with:

```
BadRequest: Resource not found for the segment 'deviceAppManagement'
```

Subsequent chunk uploads then get **403** (e.g. "Signed expiry time has to be after signed start time") because the SAS URI has expired and renewal did not succeed. The app is created in Intune but content never finishes uploading.

## Root cause

In `Add-IntuneWin32App.ps1`, `$FilesUri` is set to the **full** resource path including the `deviceAppManagement/` prefix:

```powershell
$FilesUri = "deviceAppManagement/mobileApps/$($Win32MobileAppRequest.id)/microsoft.graph.win32LobApp/contentVersions/.../files/..."
Invoke-AzureStorageBlobUpload -Resource $FilesUri ...
```

`Invoke-AzureStorageBlobUploadRenew.ps1` then prepends `deviceAppManagement/` again when calling Graph:

- POST: `"deviceAppManagement/$($Resource)/renewUpload"`  
- GET:  `"deviceAppManagement/$($Resource)"`

So the effective path becomes `deviceAppManagement/deviceAppManagement/mobileApps/...`, which is invalid. Graph returns "Resource not found for the segment 'deviceAppManagement'".

Per [Microsoft Graph](https://learn.microsoft.com/en-us/graph/api/intune-apps-mobileappcontentfile-renewupload), the correct path is:

`POST /deviceAppManagement/mobileApps/{id}/contentVersions/{contentId}/files/{fileId}/renewUpload`

The caller already passes the full path; Renew should use it as-is and only append `/renewUpload` for the POST.

## Solution

Use `$Resource` without prepending `deviceAppManagement/`:

- POST: `"$($Resource)/renewUpload"`
- GET:  `$Resource`

This has been validated in production with large Win32 packages (e.g. 3+ GB, 500+ chunks) where renewal now succeeds and upload completes.
```