### PR TITLE
Fix Get-IntuneWin32AppSupersedence.ps1 logic for single-item responses

### DIFF
--- a/Public/Get-IntuneWin32AppSupersedence.ps1
+++ b/Public/Get-IntuneWin32AppSupersedence.ps1
@@ -47,11 +47,11 @@ function Get-IntuneWin32AppSupersedence {
                 $Win32AppRelationsResponse = Invoke-MSGraphOperation -Get -APIVersion "Beta" -Resource "deviceAppManagement/mobileApps/$($Win32AppID)/relationships" -ErrorAction Stop
 
                 # Handle return value
-                if ($null -ne $Win32AppRelationsResponse -and $Win32AppRelationsResponse.Count -gt 0) {
+                if ($null -ne $Win32AppRelationsResponse) {
                     # Filter for supersedence relationships
-                    $SupersedenceRelationships = $Win32AppRelationsResponse | Where-Object { $_.'@odata.type' -eq "#microsoft.graph.mobileAppSupersedence" }
-                    if ($null -ne $SupersedenceRelationships -and $SupersedenceRelationships.Count -gt 0) {
-                        Write-Verbose -Message "Found $(@($SupersedenceRelationships).Count) supersedence relationship(s)"
+                    $SupersedenceRelationships = @($Win32AppRelationsResponse | Where-Object { $_.'@odata.type' -eq "#microsoft.graph.mobileAppSupersedence" })
+                    if ($SupersedenceRelationships.Count -gt 0) {
+                        Write-Verbose -Message "Found $($SupersedenceRelationships.Count) supersedence relationship(s)"
                         return $SupersedenceRelationships
                     }
                     else {


### PR DESCRIPTION
# Description
This PR resolves an issue where `Get-IntuneWin32AppSupersedence` fails to return data in Windows PowerShell 5.1 when exactly one relationship exists. 

In Windows PowerShell, `[PSCustomObject]` scalars do not have an intrinsic `.Count` property. By switching to a `$null` check and using the `@()` array subexpression, we ensure consistent behavior across PS 5.1 and PS 7+.

# Related Issue
Fixes #223 

# Changes
* Updated `Get-IntuneWin32AppSupersedence.ps1` to handle scalar Graph responses.
* Normalized relationship results into arrays to ensure `.Count` is always valid for logic and verbose logging.

# Testing 

## Environment
Verified on:
- Windows PowerShell 5.1 (Windows 11)
- PowerShell 7.6

## Output

The following code snippet shows the output of the execution in PowerShell 5.1, where the issue occurs.
```powershell
PS C:\> Get-IntuneWin32AppSupersedence -ID "bcce6ee9-d839-46c3-b489-e6014345b7ef"
VERBOSE: Querying for Win32 app using ID: bcce6ee9-d839-46c3-b489-e6014345b7ef
VERBOSE: GET https://graph.microsoft.com/Beta/deviceAppManagement/mobileApps/bcce6ee9-d839-46c3-b489-e6014345b7ef
VERBOSE: GET https://graph.microsoft.com/Beta/deviceAppManagement/mobileApps/bcce6ee9-d839-46c3-b489-e6014345b7ef/relationships
PS C:\> # [No data returned, script stopped at the .Count check]

PS C:\patch\Public> . ..\Private\Invoke-MSGraphOperation.ps1
PS C:\patch\Public> . ..\Private\Test-AuthenticationState.ps1
PS C:\patch\Public> . .\Get-IntuneWin32AppSupersedence.ps1
PS C:\patch\Public> Get-IntuneWin32AppSupersedence -ID "bcce6ee9-d839-46c3-b489-e6014345b7ef"
VERBOSE: Querying for Win32 app using ID: bcce6ee9-d839-46c3-b489-e6014345b7ef
VERBOSE: GET https://graph.microsoft.com/Beta/deviceAppManagement/mobileApps/bcce6ee9-d839-46c3-b489-e6014345b7ef
VERBOSE: GET https://graph.microsoft.com/Beta/deviceAppManagement/mobileApps/bcce6ee9-d839-46c3-b489-e6014345b7ef/relationships
VERBOSE: Found 1 supersedence relationship(s)

# [Object Data Returned Successfully]
```
